### PR TITLE
refactor: Use raw jsonb value

### DIFF
--- a/axon_sql.go
+++ b/axon_sql.go
@@ -24,6 +24,8 @@ func prepareQueryArgs(changesetCols []*ChangesetColumn) ([]string, []string, map
 	for _, c := range changesetCols {
 		t := reflect.TypeOf(c.Value)
 		if t != nil && t.Kind() == reflect.Map {
+			// Found a hashmap, this is a JSON/B field. Convert manually to string to
+			// avoid package sql error: "unsupported type map[string]interface {}".
 			c.Value = string(c.RawValue)
 		}
 		if t != nil && t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Interface {

--- a/axon_sql.go
+++ b/axon_sql.go
@@ -1,7 +1,6 @@
 package warppipe
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"reflect"
@@ -25,13 +24,7 @@ func prepareQueryArgs(changesetCols []*ChangesetColumn) ([]string, []string, map
 	for _, c := range changesetCols {
 		t := reflect.TypeOf(c.Value)
 		if t != nil && t.Kind() == reflect.Map {
-			// Found a hashmap, this is a JSON/B field. Convert manually to string to
-			// avoid package sql error: "unsupported type map[string]interface {}".
-			b, err := json.Marshal(c.Value)
-			if err != nil {
-				return cols, colArgs, values, fmt.Errorf("unable to marshal JSON field %s: %w", c.Column, err)
-			}
-			c.Value = string(b)
+			c.Value = string(c.RawValue)
 		}
 		if t != nil && t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Interface {
 			// Set empty slices to pq.Array(nil) to avoid package sql error on an

--- a/changeset.go
+++ b/changeset.go
@@ -78,6 +78,6 @@ func (c *Changeset) GetPreviousColumnValue(column string) (interface{}, bool) {
 type ChangesetColumn struct {
 	Column   string          `json:"column"`
 	Value    interface{}     `json:"value"`
-	RawValue json.RawMessage `json:"value_b"`
+	RawValue json.RawMessage `json:"raw_value"`
 	Type     string          `json:"type"`
 }

--- a/changeset.go
+++ b/changeset.go
@@ -1,6 +1,7 @@
 package warppipe
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -75,7 +76,8 @@ func (c *Changeset) GetPreviousColumnValue(column string) (interface{}, bool) {
 
 // ChangesetColumn represents a type and value for a column in a changeset.
 type ChangesetColumn struct {
-	Column string      `json:"column"`
-	Value  interface{} `json:"value"`
-	Type   string      `json:"type"`
+	Column   string          `json:"column"`
+	Value    interface{}     `json:"value"`
+	RawValue json.RawMessage `json:"value_b"`
+	Type     string          `json:"type"`
 }

--- a/notify_listener.go
+++ b/notify_listener.go
@@ -182,10 +182,17 @@ func (l *NotifyListener) processChangeset(event *store.Event) {
 			l.errCh <- err
 		}
 
+		var newRawValues map[string]json.RawMessage
+		err = json.Unmarshal(event.NewValues, &newRawValues)
+		if err != nil {
+			l.errCh <- err
+		}
+
 		for k, v := range newValues {
 			col := &ChangesetColumn{
-				Column: k,
-				Value:  v,
+				Column:   k,
+				Value:    v,
+				RawValue: newRawValues[k],
 			}
 			cs.NewValues = append(cs.NewValues, col)
 		}

--- a/notify_listener.go
+++ b/notify_listener.go
@@ -3,6 +3,7 @@ package warppipe
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -179,13 +180,13 @@ func (l *NotifyListener) processChangeset(event *store.Event) {
 		var newValues map[string]interface{}
 		err := json.Unmarshal(event.NewValues, &newValues)
 		if err != nil {
-			l.errCh <- err
+			l.errCh <- fmt.Errorf("failed to unmarshal changeset values: %w", err)
 		}
 
 		var newRawValues map[string]json.RawMessage
 		err = json.Unmarshal(event.NewValues, &newRawValues)
 		if err != nil {
-			l.errCh <- err
+			l.errCh <- fmt.Errorf("failed to unmarshal raw changeset values: %w", err)
 		}
 
 		for k, v := range newValues {


### PR DESCRIPTION
Fixes a problem where JSONB gets Marshaled differently to the original.

In the source db:
```
test=# select type_json from "testTable" LIMIT 5;
                 type_json
--------------------------------------------
 {"name": "Alice", "age": 31, "city": "LA"}
 {"name": "Alice", "age": 31, "city": "LA"}
```

In the target db:
```
test=# select type_json from "testTable" LIMIT 5;
               type_json
---------------------------------------
 {"age":31,"city":"LA","name":"Alice"}
 {"age":31,"city":"LA","name":"Alice"}
```

Was causing tests to fail:
```
--- FAIL: TestVersionMigration (37.34s)
    --- FAIL: TestVersionMigration/9.5To9.6 (37.34s)
        version_migrations_test.go:301: 
                Error Trace:    version_migrations_test.go:301
                Error:          Received unexpected error:
                                checksums differ for table public.testTable
                Test:           TestVersionMigration/9.5To9.6
FAIL
FAIL    github.com/perangel/warp-pipe/tests/integration 39.430s
FAIL
```

Tests now parse: 
```
 10:22 $ go test ./...
ok      github.com/perangel/warp-pipe   (cached)
?       github.com/perangel/warp-pipe/build/demo-service        [no test files]
?       github.com/perangel/warp-pipe/cmd/axon  [no test files]
?       github.com/perangel/warp-pipe/cmd/warp-pipe     [no test files]
?       github.com/perangel/warp-pipe/db        [no test files]
?       github.com/perangel/warp-pipe/internal/cli      [no test files]
?       github.com/perangel/warp-pipe/internal/store    [no test files]
ok      github.com/perangel/warp-pipe/tests/integration (cached)
```