### PR TITLE
fix: Correct empty array in prepareQueryArgs

### DIFF
--- a/axon_sql.go
+++ b/axon_sql.go
@@ -34,7 +34,7 @@ func prepareQueryArgs(changesetCols []*ChangesetColumn) ([]string, []string, map
 			// empty character varying[]: "unsupported type []interface {}, a slice of
 			// interface"
 			if reflect.ValueOf(c.Value).Len() == 0 {
-				c.Value = pq.Array(nil)
+				c.Value = []byte("{}")
 			} else {
 				c.Value = pq.Array(c.Value)
 			}


### PR DESCRIPTION
Resolves:
```
{"error":"PG error 23502:not_null_violation failed to update {timestamp: 2021-02-23 16:02:34.236897 -0800 PST, kind: update, schema: public, table: TABLE} for query INSERT INTO \"public\".\"TABLE\" (id, tags) VALUES (:id, :tags) ON CONFLICT (id) DO UPDATE SET id = :id, tags = :tags WHERE \"TABLE\".id = :id args tags:{\u003cnil\u003e}: pq: null value in column \"tags\" violates not-null constraint","level":"error","msg":"failed to UPDATE row for table 'TABLE' (pk: [id])","table":"TABLE","time":"2021-02-23T16:58:59-08:00"}
```
_redacted table specifics_