### PR TITLE
improve: Align row insert/update/delete log msgs

### DIFF
--- a/axon_sql.go
+++ b/axon_sql.go
@@ -155,7 +155,9 @@ func insertRow(sourceDB *sqlx.DB, targetDB *sqlx.DB, change *Changeset) error {
 		return err
 	}
 
-	log.Printf("row inserted: %s", change)
+	// NOTE: row insert/update/delete logs have been updated to be the same length
+	// to align timestamps to ease viewing.
+	log.Printf("row insert: %s", change)
 	return nil
 }
 
@@ -175,7 +177,7 @@ func updateRow(targetDB *sqlx.DB, change *Changeset, primaryKey []string) error 
 
 		return fmt.Errorf("PG error %s:%s failed to update %s for query %s args %s: %+v", pqe.Code, pqe.Code.Name(), change, removeDuplicateSpaces(query), args, err)
 	}
-	log.Printf("row updated: %s", change)
+	log.Printf("row update: %s", change)
 	return nil
 }
 
@@ -189,6 +191,6 @@ func deleteRow(targetDB *sqlx.DB, change *Changeset, primaryKey []string) error 
 		}
 		return fmt.Errorf("PG error %s:%s delete to update %s for query %s: %+v", pqe.Code, pqe.Code.Name(), change, removeDuplicateSpaces(query), err)
 	}
-	log.Printf("row deleted: %s", change)
+	log.Printf("row delete: %s", change)
 	return nil
 }


### PR DESCRIPTION
nit...

This
```
2021/02/24 22:32:44 row inserted: {timestamp: 2021-02-24 22:23:44.969504 +0000 UTC, kind: insert, schema: public, table: sharedcache}
2021/02/24 22:32:44 row updated: {timestamp: 2021-02-24 22:23:45.044179 +0000 UTC, kind: update, schema: public, table: star}
2021/02/24 22:32:44 row deleted: {timestamp: 2021-02-24 22:23:45.285069 +0000 UTC, kind: delete, schema: public, table: sharedcache}
```

to
```
2021/02/24 22:32:44 row insert: {timestamp: 2021-02-24 22:23:44.969504 +0000 UTC, kind: insert, schema: public, table: sharedcache}
2021/02/24 22:32:44 row update: {timestamp: 2021-02-24 22:23:45.044179 +0000 UTC, kind: update, schema: public, table: star}
2021/02/24 22:32:44 row delete: {timestamp: 2021-02-24 22:23:45.285069 +0000 UTC, kind: delete, schema: public, table: sharedcache}
```
