### PR TITLE
improve: print changeset ID

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -58,7 +58,7 @@ func (c *Changeset) String() string {
 	// While c.newValues is an ordered array, the original data source is a JSON
 	// object used as a hashmap, therefore the data is stored as a map in Go
 	// which means the field order in the array is randomized.
-	return fmt.Sprintf("{timestamp: %s, kind: %s, schema: %s, table: %s}", c.Timestamp, c.Kind, c.Schema, c.Table)
+	return fmt.Sprintf("{id: %d, timestamp: %s, kind: %s, schema: %s, table: %s}", c.ID, c.Timestamp, c.Kind, c.Schema, c.Table)
 }
 
 // GetNewColumnValue returns the current value for a column and a bool denoting


### PR DESCRIPTION
This came up during today's migration call, seems like handy information to have.