### PR TITLE
feat: Verbose record-by-record VerifyChangesets on diff, add a strictly ordered buffer queue to NotifyListener 

### DIFF
--- a/axon.go
+++ b/axon.go
@@ -290,7 +290,7 @@ func (a *Axon) Verify(schemas, includeTables, excludeTables []string) error {
 	return nil
 }
 
-func (a *Axon) VerifyChangesets() error {
+func (a *Axon) VerifyChangesets(lastID int64) error {
 	sourceDBConn, targetDBConn, err := a.getDB()
 	if err != nil {
 		return fmt.Errorf("cannot connect to DB: %w", err)
@@ -299,10 +299,10 @@ func (a *Axon) VerifyChangesets() error {
 	defer targetDBConn.Close()
 
 	where := ""
-	// TODO: axon Verify just checks all for now, but should support limits in the future.
-	// if lastID > 0 {
-	// 	where = fmt.Sprintf("WHERE id <= %d", lastID)
-	// }
+
+	if lastID > 0 {
+		where = fmt.Sprintf("WHERE id <= %d", lastID)
+	}
 
 	a.Logger.Info("beginning verbose check")
 	// Compare changeset records one by one

--- a/axon_schema.go
+++ b/axon_schema.go
@@ -52,14 +52,14 @@ func checkTargetVersion(conn *sqlx.DB) error {
 	return nil
 }
 
-func printSourceStats(conn *sqlx.DB) error {
+func printStats(conn *sqlx.DB, name string) (int, error) {
 	var changesetCount int
 	err := conn.Get(&changesetCount, "SELECT count(id) FROM warp_pipe.changesets")
 	if err != nil {
-		return err
+		return 0, err
 	}
-	log.Printf("Changesets Found in Source: %d", changesetCount)
-	return nil
+	log.Printf("Changesets found in %s: %d", name, changesetCount)
+	return changesetCount, nil
 }
 
 func loadPrimaryKeys(conn *sqlx.DB) error {
@@ -234,8 +234,8 @@ func loadColumnTypes(conn *sqlx.DB) error {
 	}
 
 	err := conn.Select(&rows, `
-		SELECT table_schema, table_name, column_name, data_type 
-		FROM information_schema.columns 
+		SELECT table_schema, table_name, column_name, data_type
+		FROM information_schema.columns
 		WHERE table_schema NOT IN ('pg_catalog', 'information_schema', 'warp_pipe');`,
 	)
 	if err != nil {

--- a/internal/store/changeset_store.go
+++ b/internal/store/changeset_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx"
@@ -27,6 +28,16 @@ type Event struct {
 	OID        int64
 	NewValues  []byte
 	OldValues  []byte
+}
+
+// String implements the Stringer interface to prettyprint the struct
+func (e *Event) String() string {
+	newValues := strings.Replace(string(e.NewValues), "\"", "'", -1)
+	newValues = strings.Replace(newValues, "\n", "", -1)
+	oldValues := strings.Replace(string(e.OldValues), "\"", "'", -1)
+	oldValues = strings.Replace(oldValues, "\n", "", -1)
+	return fmt.Sprintf("ID: %d, Timestamp: %s, Action: %s, TableName: %s, NewValues: %s, OldValues: %s",
+		e.ID, e.Timestamp, e.Action, e.TableName, newValues, oldValues)
 }
 
 // EventStore is the interface for providing access to events storage.
@@ -118,13 +129,13 @@ func (s *ChangesetStore) GetSinceID(ctx context.Context, eventID int64, eventCh 
 			ts,
 			action,
 			schema_name,
-			table_name,	
+			table_name,
 			relid,
 			new_values,
 			old_values
 		FROM warp_pipe.changesets
 			WHERE id >= $1
-			ORDER BY id 
+			ORDER BY id
 			LIMIT %d
 			OFFSET %d`
 
@@ -157,7 +168,7 @@ func (s *ChangesetStore) GetSinceTimestamp(ctx context.Context, since time.Time,
 			ts,
 			action,
 			schema_name,
-			table_name,	
+			table_name,
 			relid,
 			new_values,
 			old_values

--- a/tests/integration/version_migrations_test.go
+++ b/tests/integration/version_migrations_test.go
@@ -374,7 +374,7 @@ func TestVersionMigration(t *testing.T) {
 			require.NoError(t, err)
 
 			errVerify := axon.Verify(schemas, includeTables, excludeTables)
-			errVerifyChangesets := axon.VerifyChangesets()
+			errVerifyChangesets := axon.VerifyChangesets(-1)
 
 			require.NoError(t, errVerify)
 			require.NoError(t, errVerifyChangesets)

--- a/tests/integration/version_migrations_test.go
+++ b/tests/integration/version_migrations_test.go
@@ -309,7 +309,7 @@ func TestVersionMigration(t *testing.T) {
 
 			// write, update, delete to produce change sets
 			var insertsWG, updatesWG, deletesWG sync.WaitGroup
-			workersCount := 5
+			workersCount := 10
 			for i := 0; i < workersCount; i++ {
 				insertsWG.Add(1)
 				go insertTestData(t, srcDBConfig, 10, &insertsWG)
@@ -339,9 +339,12 @@ func TestVersionMigration(t *testing.T) {
 				TargetDBPass:               targetDBConfig.Password,
 				TargetDBSchema:             "public",
 				ShutdownAfterLastChangeset: true,
+				FailOnDuplicate:            true,
 			}
 
 			axon := warppipe.Axon{Config: &axonCfg}
+
+			time.Sleep(100 * time.Millisecond) // allow the writes to be occur.
 
 			t.Log("first pass sync")
 			err = axon.Run()
@@ -352,7 +355,21 @@ func TestVersionMigration(t *testing.T) {
 			updatesWG.Wait()
 			deletesWG.Wait()
 
-			t.Log("second pass sync. starting from beginning, and catching any stragglers")
+			for i := 0; i < workersCount; i++ {
+				insertsWG.Add(1)
+				go insertTestData(t, srcDBConfig, 10, &insertsWG)
+			}
+			insertsWG.Wait()
+
+			t.Log("second pass sync. starting from last ID in target, catching any stragglers")
+			row, err := targetConn.Query("SELECT max(id) from warp_pipe.changesets")
+			require.True(t, row.Next())
+			var count int64
+			row.Scan(&count)
+			t.Logf("last target changeset id: %d", count)
+
+			axon.Config.StartFromID = count + 1
+
 			err = axon.Run()
 			require.NoError(t, err)
 

--- a/tests/integration/version_migrations_test.go
+++ b/tests/integration/version_migrations_test.go
@@ -293,6 +293,7 @@ func TestVersionMigration(t *testing.T) {
 			includeTables := make([]string, 0)
 			excludeTables := make([]string, 0)
 
+			// Setup WP on source
 			wpConn, err := pgx.Connect(srcDBConfig)
 			require.NoError(t, err)
 
@@ -301,7 +302,7 @@ func TestVersionMigration(t *testing.T) {
 
 			// write, update, delete to produce change sets
 			var insertsWG, updatesWG, deletesWG sync.WaitGroup
-			workersCount := 20
+			workersCount := 5
 			for i := 0; i < workersCount; i++ {
 				insertsWG.Add(1)
 				go insertTestData(t, srcDBConfig, 10, &insertsWG)
@@ -309,12 +310,12 @@ func TestVersionMigration(t *testing.T) {
 
 			for i := 0; i < workersCount; i++ {
 				updatesWG.Add(1)
-				go updateTestData(t, srcDBConfig, 30, &updatesWG)
+				go updateTestData(t, srcDBConfig, 10, &updatesWG)
 			}
 
 			for i := 0; i < workersCount; i++ {
 				deletesWG.Add(1)
-				go deleteTestData(t, srcDBConfig, 30, &deletesWG)
+				go deleteTestData(t, srcDBConfig, 10, &deletesWG)
 			}
 
 			// sync source and target with Axon

--- a/tests/integration/version_migrations_test.go
+++ b/tests/integration/version_migrations_test.go
@@ -300,6 +300,13 @@ func TestVersionMigration(t *testing.T) {
 			err = db.Prepare(wpConn, []string{"public"}, []string{"testTable"}, []string{})
 			require.NoError(t, err)
 
+			// Setup WP on target
+			targetConn, err := pgx.Connect(targetDBConfig)
+			require.NoError(t, err)
+
+			err = db.Prepare(targetConn, []string{"public"}, []string{"testTable"}, []string{})
+			require.NoError(t, err)
+
 			// write, update, delete to produce change sets
 			var insertsWG, updatesWG, deletesWG sync.WaitGroup
 			workersCount := 5

--- a/tests/integration/version_migrations_test.go
+++ b/tests/integration/version_migrations_test.go
@@ -356,8 +356,11 @@ func TestVersionMigration(t *testing.T) {
 			err = axon.Run()
 			require.NoError(t, err)
 
-			err = axon.Verify(schemas, includeTables, excludeTables)
-			require.NoError(t, err)
+			errVerify := axon.Verify(schemas, includeTables, excludeTables)
+			errVerifyChangesets := axon.VerifyChangesets()
+
+			require.NoError(t, errVerify)
+			require.NoError(t, errVerifyChangesets)
 		})
 	}
 }


### PR DESCRIPTION
Added a verbose verification process logs outputting all incorrect records:
```
{"level":"error","msg":"source/target rows differ, source: ID: 708, Timestamp: 0001-01-01 00:00:00 +0000 UTC, Action: INSERT, TableName: testTable, NewValues: {'id':'741b7646-7fd8-11eb-8126-47be13731793', 'type_text':'a test string', 'type_date':'2021-03-07', 'type_boolean':true, 'type_json':{'name': 'Alice', 'age': 31, 'city': 'LA'}, 'type_jsonb':{'age': 39, 'city': 'London', 'name': 'Bob'}, 'type_array':[1,2,3,4,5], 'type_bytea':'\\\\x616263646566'}, OldValues:  target: ID: 708, Timestamp: 0001-01-01 00:00:00 +0000 UTC, Action: INSERT, TableName: testTable, NewValues: {'id':'741b7646-7fd8-11eb-8126-47be13731793', 'type_text':'a test string', 'type_date':'2021-03-07', 'type_boolean':true, 'type_json':{'name': 'Alice', 'age': 31, 'city': 'LA'}, 'type_jsonb':{'age': 39, 'city': 'London', 'name': 'Bob'}, 'type_array':[1,2,3,4,5], 'type_bytea':'\\\\x5c78363136323633363436353636'}, OldValues: ","time":"2021-03-07T22:35:23-08:00"}
{"level":"info","msg":"verbose check failed","time":"2021-03-07T22:35:23-08:00"}
```

Manually test verbose logs by disabling `bytea` field type handling in `axon_sql.go` https://github.com/udacity/warp-pipe/blob/6d46bb16e2c58d6073fdae553ef1d93cbb12f915/axon_sql.go#L43-L47

The verbose logs enabled Shiva and I to prove the notifylistener does NOT receive Changeset records in strict ID order. I created a strictly-ordered buffered queue to enforce the order. I suspect a lower level bug exists, but this is an acceptable workaround for now.
