### PR TITLE
WIP fix: Fix race condition for changeset id order

### DIFF
--- a/db/sql.go
+++ b/db/sql.go
@@ -43,6 +43,7 @@ const (
 		CREATE OR REPLACE FUNCTION warp_pipe.on_modify()
 			RETURNS TRIGGER AS $$
 				BEGIN
+					LOCK TABLE warp_pipe.changesets IN EXCLUSIVE MODE;
 					IF TG_WHEN <> 'AFTER' THEN
 						RAISE EXCEPTION 'warp_pipe.on_modify() may only run as an AFTER trigger';
 					END IF;


### PR DESCRIPTION
This change ensures an exclusive lock on `warp_pipe.changesets` table when the trigger executes the `on_modify` function. It bypasses the `handleChangeset` func, and panics if the id is not what is expected. This logic can be changed but it was used to validate the change.

So I have tested this change with the following:
```
time while [ true ]; do go test -race -run TestVersionMigration -v ./tests/integration/... -integration; docker stop $(docker ps -aq) && docker rm $(docker ps -aq); done |tee -a /tmp/integ.log
```
 
Which ran for quite a while:
```
real    420m27.465s
user    6m59.337s
sys     4m16.076s
```

The log file ended up looking like:
```
ls -lah /tmp/integ.log
-rw-r--r--  1 jpye  wheel    28M Mar 10 04:07 /tmp/integ.log
```

The only failure was unrelated:
```
=== RUN   TestVersionMigration/9.5To9.6
container e8e5e46266fb5fe0e6c1daa4165708ab640c5e88852140b5a79243a91f97aeb2 is started
    version_migrations_test.go:279:
                Error Trace:    version_migrations_test.go:279
                Error:          Received unexpected error:
                                unable to start the container: Error response from daemon: Ports are not available: listen tcp 0.0.0.0:63715: bind: address already in use
                Test:           TestVersionMigration/9.5To9.6
container e8e5e46266fb5fe0e6c1daa4165708ab640c5e88852140b5a79243a91f97aeb2 is stopping
container e8e5e46266fb5fe0e6c1daa4165708ab640c5e88852140b5a79243a91f97aeb2 is stopped
container e8e5e46266fb5fe0e6c1daa4165708ab640c5e88852140b5a79243a91f97aeb2 is removed
--- FAIL: TestVersionMigration (6.76s)
    --- FAIL: TestVersionMigration/9.5To9.6 (6.76s)
FAIL
FAIL    github.com/perangel/warp-pipe/tests/integration 7.698s
FAIL
```

Im not sure if this a silver bullet, but I was seeing panics on almost every run when there was no lock yesterday.