### PR TITLE
Enable custom images with integration test to add custom pg_hba.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION ?= $(shell git rev-parse --short HEAD)
+
 .PHONY: all
 all:
 	@cd cmd/warp-pipe && go build -v
@@ -16,4 +18,5 @@ demo-clean:
 
 .PHONY: integration-test
 integration-test:
-	go test -v ./tests/integration -integration
+	docker build -f ./build/postgres/Dockerfile -t psql-int-test:$(VERSION) .
+	BUILD_SHA=$(VERSION) go test -v ./tests/integration -integration

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -12,6 +12,7 @@ RUN cd /opt && \
     USE_PGXS=1 make install
 
 COPY build/postgres/postgresql.conf /etc/postgres/postgresql.conf
+COPY build/postgres/pg_hba.conf /etc/postgres/pg_hba.conf
 RUN chown -R postgres:postgres /etc/postgres
 
-CMD ["postgres", "-c", "config_file=/etc/postgres/postgresql.conf"]
+CMD ["postgres", "-cconfig_file=/etc/postgres/postgresql.conf", "-chba_file=/etc/postgres/pg_hba.conf"]

--- a/build/postgres/pg_hba.conf
+++ b/build/postgres/pg_hba.conf
@@ -1,0 +1,2 @@
+# Default configuration - for TCP connections to all databases/users/addresses, require md5 authentication
+host all all all md5

--- a/tests/integration/version_migrations_test.go
+++ b/tests/integration/version_migrations_test.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	warppipe "github.com/perangel/warp-pipe"
@@ -250,6 +252,8 @@ func deleteTestData(t *testing.T, config pgx.ConnConfig, nRows int, wg *sync.Wai
 }
 
 func TestVersionMigration(t *testing.T) {
+	buildSha := os.Getenv("BUILD_SHA")
+	assert.NotEmpty(t, buildSha)
 
 	testCases := []struct {
 		name   string
@@ -260,6 +264,11 @@ func TestVersionMigration(t *testing.T) {
 			name:   "9.5To9.6",
 			source: "postgres:9.5",
 			target: "postgres:9.6",
+		},
+		{
+			name:   "custom11To11",
+			source: "psql-int-test:" + buildSha,
+			target: "postgres:11-alpine",
 		},
 	}
 

--- a/tests/integration/version_migrations_test.go
+++ b/tests/integration/version_migrations_test.go
@@ -99,7 +99,7 @@ func waitForPostgresReady(config *pgx.ConnConfig) bool {
 	return connected
 }
 
-func createDatabaseContainer(t *testing.T, ctx context.Context, version string, database string, username string, password string) (string, int, error) {
+func createDatabaseContainer(t *testing.T, ctx context.Context, image string, database string, username string, password string) (string, int, error) {
 	postgresPort := 5432
 
 	docker, err := NewDockerClient()
@@ -115,7 +115,7 @@ func createDatabaseContainer(t *testing.T, ctx context.Context, version string, 
 	container, err := docker.runContainer(
 		ctx,
 		&ContainerConfig{
-			image: fmt.Sprintf("postgres:%s", version),
+			image: image,
 			ports: []*PortMapping{
 				{
 					HostPort:      fmt.Sprintf("%d", hostPort),
@@ -258,8 +258,8 @@ func TestVersionMigration(t *testing.T) {
 	}{
 		{
 			name:   "9.5To9.6",
-			source: "9.5",
-			target: "9.6",
+			source: "postgres:9.5",
+			target: "postgres:9.6",
 		},
 	}
 


### PR DESCRIPTION
[Documentation on config file](https://www.postgresql.org/docs/9.6/auth-pg-hba-conf.html)

This is a prerequisite for running in `Logical Replication` mode, as the default permissions do *not* allow access to replication slots.

Test output:
```
--- PASS: TestVersionMigration (28.79s)
    --- PASS: TestVersionMigration/9.5To9.6 (16.88s)
    --- PASS: TestVersionMigration/custom11To11 (11.91s)
PASS
ok      github.com/perangel/warp-pipe/tests/integration 28.794s
```