### PR TITLE
test: Ensure replication connection can be formed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ lint:
 test:
 	go test -v ./...
 
+.PHONY: build-psql-%
+build-psql-%:
+	docker build --quiet --build-arg PSQL_VERSION=$* -f ./build/postgres/Dockerfile -t psql-int-test:$*-$(VERSION) .
+
 .PHONY: integration-test
-integration-test:
-	docker build -f ./build/postgres/Dockerfile -t psql-int-test:$(VERSION) .
+integration-test: build-psql-9 build-psql-10 build-psql-11 build-psql-12
 	BUILD_SHA=$(VERSION) go test -v ./tests/integration -integration

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -1,4 +1,5 @@
-FROM postgres:11-alpine
+ARG PSQL_VERSION=12.6
+FROM postgres:$PSQL_VERSION-alpine
 
 RUN apk add --update git make gcc clang llvm musl-dev
 

--- a/tests/integration/replication_connect_test.go
+++ b/tests/integration/replication_connect_test.go
@@ -1,0 +1,88 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type pgsLogWrap struct {
+	logger *log.Entry
+}
+
+func (l *pgsLogWrap) Log(level pgx.LogLevel, msg string, data map[string]interface{}) {
+	l.logger.WithFields(data).Log(log.Level(level), msg)
+}
+
+func TestReplicationConnect(t *testing.T) {
+	buildSha := os.Getenv("BUILD_SHA")
+	assert.NotEmpty(t, buildSha)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		image                         string
+		expectReplicationConnectError bool
+	}{
+		{
+			image:                         "postgres:9",
+			expectReplicationConnectError: true,
+		},
+		{
+			image: "postgres:10",
+		},
+		{
+			image: "postgres:11",
+		},
+		{
+			image: "postgres:12",
+		},
+		{
+			image:                         "psql-int-test:9-" + buildSha,
+			expectReplicationConnectError: true,
+		},
+		{
+			image: "psql-int-test:10-" + buildSha,
+		},
+		{
+			image: "psql-int-test:11-" + buildSha,
+		},
+		{
+			image: "psql-int-test:12-" + buildSha,
+		},
+	} {
+		tc := tc // capture range variable <https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721#how-to-solve-this>
+		t.Run(tc.image, func(t *testing.T) {
+			t.Parallel()
+
+			_, srcPort, err := createDatabaseContainer(t, ctx, tc.image, dbUser, dbPassword, dbName)
+			require.NoError(t, err)
+			time.Sleep(10 * time.Second) // Wait for postgres to start
+
+			srcDBConfig := pgx.ConnConfig{
+				Host:     "127.0.0.1",
+				Port:     uint16(srcPort),
+				User:     dbUser,
+				Password: dbPassword,
+				Database: dbName,
+				Logger:   &pgsLogWrap{log.NewEntry(log.New())},
+			}
+
+			_, err = pgx.Connect(srcDBConfig)
+			require.NoError(t, err)
+
+			_, err = pgx.ReplicationConnect(srcDBConfig)
+			if tc.expectReplicationConnectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+		})
+	}
+}

--- a/tests/integration/version_migrations_test.go
+++ b/tests/integration/version_migrations_test.go
@@ -269,14 +269,16 @@ func TestVersionMigration(t *testing.T) {
 		},
 		{
 			name:         "custom11To11",
-			source:       "psql-int-test:" + buildSha,
+			source:       "psql-int-test:11-" + buildSha,
 			target:       "postgres:11-alpine",
 			listenerMode: warppipe.ListenerModeNotify,
 		},
 	}
 
 	for _, tc := range testCases {
+		tc := tc // capture range element, required for parallel
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 
 			// bring up source and target database containers


### PR DESCRIPTION
This test mostly demonstrates that out-of-the-box replication connection
is only supported on postgres images > 9. As we are currently running
12.6 in production, this shouldn't be an issue for actual use.

Test output:
```
--- PASS: TestReplicationConnect (0.00s)
    --- PASS: TestReplicationConnect/psql-int-test:11-a9b5bca (13.42s)
    --- PASS: TestReplicationConnect/psql-int-test:12-a9b5bca (13.68s)
    --- PASS: TestReplicationConnect/psql-int-test:10-a9b5bca (13.93s)
    --- PASS: TestReplicationConnect/postgres:9 (14.13s)
    --- PASS: TestReplicationConnect/postgres:11 (14.31s)
    --- PASS: TestReplicationConnect/postgres:12 (14.53s)
    --- PASS: TestReplicationConnect/psql-int-test:9-a9b5bca (14.69s)
    --- PASS: TestReplicationConnect/postgres:10 (14.84s)
--- PASS: TestVersionMigration (0.00s)
    --- PASS: TestVersionMigration/custom11To11 (23.41s)
    --- PASS: TestVersionMigration/9.5To9.6 (26.15s)
```