### PR TITLE
feat: Add replication mode config/skeleton to axon.Run

### DIFF
--- a/axon_config_test.go
+++ b/axon_config_test.go
@@ -1,0 +1,61 @@
+package warppipe
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAxonConfigListenerMode(t *testing.T) {
+	envVarListenerMode := "AXON_LISTENER_MODE"
+
+	for _, tc := range []struct {
+		name       string
+		vars       map[string]string
+		expectMode string
+		expectErr  bool
+	}{
+		{
+			name:       "default (notify)",
+			expectMode: ListenerModeNotify,
+		},
+		{
+			name: "specify notify",
+			vars: map[string]string{
+				envVarListenerMode: ListenerModeNotify,
+			},
+			expectMode: ListenerModeNotify,
+		},
+		{
+			name: "specify replication",
+			vars: map[string]string{
+				envVarListenerMode: ListenerModeLogicalReplication,
+			},
+			expectMode: ListenerModeLogicalReplication,
+		},
+		{
+			name: "bad mode",
+			vars: map[string]string{
+				envVarListenerMode: "garbage",
+			},
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for key, val := range tc.vars {
+				assert.NoError(t, os.Setenv(key, val))
+				defer os.Unsetenv(key)
+			}
+
+			config, err := NewAxonConfigFromEnv()
+
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectMode, config.ListenerMode)
+			}
+		})
+	}
+}

--- a/lr_listener.go
+++ b/lr_listener.go
@@ -51,6 +51,13 @@ func HeartbeatInterval(seconds int) LROption {
 	}
 }
 
+// LRLogger is an option for setting the logger
+func LRLogger(logger *log.Logger) LROption {
+	return func(l *LogicalReplicationListener) {
+		l.logger = logger.WithFields(log.Fields{"component": "listener"})
+	}
+}
+
 // LogicalReplicationListener is a Listener that uses logical replication slots
 // to listen for changesets.
 type LogicalReplicationListener struct {


### PR DESCRIPTION
This is a subset of the changes contained in #37 and is intended to be a more focused/digestible/reviewable change.

Reviewing `Files changed` is much easier with `view: split; whitespace-changes: hide` settings.

Some notes:
* I went with `switch ReplicationMode` instead of `if ReplicationMode == ...` even when there was only logic for a single mode, with the aim of consistently communicating `this is a mode-specific section of code`. Avoiding the `if ... else if ... else if` ladder was the main concern for readability.
* Sections of `LogicalReplication` mode logic have had space created from them (via `switch/case`) but have not been implemented. Those changes are for a future PR, and this set of changes does not alter current behavior for `Notify` listener mode.
* I'm aware that there's some messy overlap between `config.go` and `axon_config.go` - reconciling that mess is out of scope for this PR (but hopefully will be included as a polishing refactor step once logical changes are in.

Test output:
```
--- PASS: TestVersionMigration (27.41s)
    --- PASS: TestVersionMigration/9.5To9.6 (15.75s)
    --- PASS: TestVersionMigration/custom11To11 (11.65s)
PASS
ok      github.com/perangel/warp-pipe/tests/integration 27.411s
```