### PR TITLE
fix: More durable parsing of semver from db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ demo:
 demo-clean:
 	docker-compose -f docker-compose.demo.yml rm -f -s
 
+.PHONY: test
+test:
+	go test -v ./...
+
 .PHONY: integration-test
 integration-test:
 	docker build -f ./build/postgres/Dockerfile -t psql-int-test:$(VERSION) .

--- a/axon_schema_test.go
+++ b/axon_schema_test.go
@@ -1,0 +1,27 @@
+package warppipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSemver(t *testing.T) {
+	for _, tc := range []struct {
+		raw   string
+		major int
+		minor int
+	}{
+		{raw: "9.5", major: 9, minor: 5},
+		{raw: "9.5   (And some other stuff...", major: 9, minor: 5},
+		{raw: "9.5.1  (patch version ignored)", major: 9, minor: 5},
+		{raw: "12.34  (multi-digit check)", major: 12, minor: 34},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			major, minor, err := parseSemver(tc.raw)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.major, major)
+			assert.Equal(t, tc.minor, minor)
+		})
+	}
+}


### PR DESCRIPTION
Testing for LogicalReplication listener mode revealed that newer PSQL
images include additional build information in the 'SHOW server_version'
call. This is a slightly more robust version of the initial
implementation (with added tests).

This is a subset of the changes contained in #37 and is intended to be a more focused/digestible/reviewable change.

Unit test output:
```
$ make test
go test -v ./...
=== RUN   TestParseSemver
=== RUN   TestParseSemver/9.5
=== RUN   TestParseSemver/9.5___(And_some_other_stuff...
=== RUN   TestParseSemver/9.5.1__(patch_version_ignored)
--- PASS: TestParseSemver (0.00s)
    --- PASS: TestParseSemver/9.5 (0.00s)
    --- PASS: TestParseSemver/9.5___(And_some_other_stuff... (0.00s)
    --- PASS: TestParseSemver/9.5.1__(patch_version_ignored) (0.00s)
=== RUN   TestPipeline
--- PASS: TestPipeline (0.30s)
=== RUN   TestNewConfigFromEnv
=== RUN   TestNewConfigFromEnv/test_with_namespace
=== RUN   TestNewConfigFromEnv/test_with_no_namespace
=== RUN   TestNewConfigFromEnv/test_parse_database_config
--- PASS: TestNewConfigFromEnv (0.00s)
    --- PASS: TestNewConfigFromEnv/test_with_namespace (0.00s)
    --- PASS: TestNewConfigFromEnv/test_with_no_namespace (0.00s)
    --- PASS: TestNewConfigFromEnv/test_parse_database_config (0.00s)
=== RUN   TestParseLogLevel
--- PASS: TestParseLogLevel (0.00s)
PASS
ok      github.com/perangel/warp-pipe   (cached)
?       github.com/perangel/warp-pipe/cmd/axon  [no test files]
?       github.com/perangel/warp-pipe/cmd/warp-pipe     [no test files]
?       github.com/perangel/warp-pipe/db        [no test files]
?       github.com/perangel/warp-pipe/internal/cli      [no test files]
?       github.com/perangel/warp-pipe/internal/store    [no test files]
Integration tests disabled. Use -integration flag to enable.
ok      github.com/perangel/warp-pipe/tests/integration 0.004s
```

Integration test output:
```
--- PASS: TestVersionMigration (26.37s)
    --- PASS: TestVersionMigration/9.5To9.6 (14.63s)
    --- PASS: TestVersionMigration/custom11To11 (11.74s)
PASS
ok      github.com/perangel/warp-pipe/tests/integration 26.373s
```